### PR TITLE
docs: fix broken links in documentation

### DIFF
--- a/bonded-validators-setup/lido-csm/exiting-csm-validators/proper-exits.md
+++ b/bonded-validators-setup/lido-csm/exiting-csm-validators/proper-exits.md
@@ -6,7 +6,7 @@ Exiting CSM-deposited validator keys works the same way as exiting solo staking 
 
 Refer to this dedicated guide for exiting validators put together by Remy Roy.
 
-{% embed url="https://github.com/eth-educators/ethstaker-guides/blob/main/voluntary-exit.md" %}
+{% embed url="https://github.com/ethstaker/ethstaker-guides/blob/main/docs/voluntary-exit.md" %}
 
 You can also follow the steps extracted from Remy's guide below (Linux only).
 

--- a/native-solo-staking-setup/exiting-your-validator.md
+++ b/native-solo-staking-setup/exiting-your-validator.md
@@ -2,4 +2,4 @@
 
 Follow the dedicated guide to exit your validators below put together by Remy Roy.&#x20;
 
-{% embed url="https://github.com/eth-educators/ethstaker-guides/blob/main/voluntary-exit.md" %}
+{% embed url="https://github.com/ethstaker/ethstaker-guides/blob/main/docs/voluntary-exit.md" %}

--- a/useful-resources/general-resources.md
+++ b/useful-resources/general-resources.md
@@ -8,7 +8,7 @@
 * [How to choose the right CPU](https://sech.me/boinc/Amicable/cpu_list.php)
 * [Somer Esat's guides](https://github.com/SomerEsat/ethereum-staking-guides)
 * [Coincashew's guides](https://www.coincashew.com/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet)
-* [Remi Roy's Mevboost guide](https://github.com/eth-educators/ethstaker-guides/blob/main/prepare-for-the-merge.md#update-mev-boost)
+* [Remi Roy's Mevboost guide](https://github.com/ethstaker/ethstaker-guides/blob/main/docs/prepare-for-the-merge.md#update-mev-boost)
 * Client diversity dashboard - [EL](https://www.ethernodes.org/) & [CL](https://clientdiversity.org/)
 * [Importance of client diversity](https://ethereum.org/en/developers/docs/nodes-and-clients/client-diversity/)
 * Ethereum Beacon Deposit Contract Address on [Etherscan](https://etherscan.io/address/0x00000000219ab540356cBB839Cbe05303d7705Fa)


### PR DESCRIPTION
This merge request fixes broken links found across the project documentation and replace the old name of the repository eth-educators to ethstaker.